### PR TITLE
Add JSON-LD structured data for SEO

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,70 @@ import {
   BlogSection,
 } from "@/components";
 
-
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "https://www.kartikeytripathi.in/#person",
+      name: "Kartikey Tripathi",
+      jobTitle: "Cloud & DevOps Engineer",
+      url: "https://www.kartikeytripathi.in",
+      email: "kartikey.tripathi.37@gmail.com",
+      image: "https://www.kartikeytripathi.in/images/about/KT.JPG",
+      sameAs: [
+        "https://github.com/kartikeytripathi",
+        "https://www.linkedin.com/in/kartikeytripathi",
+        "https://www.instagram.com/kar.ti.key",
+      ],
+      worksFor: {
+        "@type": "Organization",
+        name: "Amazon Web Services",
+        url: "https://aws.amazon.com",
+      },
+      knowsAbout: [
+        "AWS",
+        "Kubernetes",
+        "Docker",
+        "DevOps",
+        "Cloud Engineering",
+        "EKS",
+        "ECS",
+        "Terraform",
+        "CI/CD",
+      ],
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Hyderabad",
+        addressRegion: "Telangana",
+        addressCountry: "IN",
+      },
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://www.kartikeytripathi.in/#website",
+      name: "Kartikey Tripathi — Cloud & DevOps Engineer",
+      url: "https://www.kartikeytripathi.in",
+      author: { "@id": "https://www.kartikeytripathi.in/#person" },
+    },
+    {
+      "@type": "ProfilePage",
+      "@id": "https://www.kartikeytripathi.in/#profilepage",
+      url: "https://www.kartikeytripathi.in",
+      name: "Kartikey Tripathi Portfolio",
+      about: { "@id": "https://www.kartikeytripathi.in/#person" },
+      mainEntity: { "@id": "https://www.kartikeytripathi.in/#person" },
+    },
+  ],
+};
 
 export default function Portfolio() {
   return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
     <main className="max-w-4xl mx-auto p-6 lg:p-8 bg-background text-foreground">
       <FadeInUp delay={0.1}>
   <HeroSection />
@@ -51,5 +111,6 @@ export default function Portfolio() {
   © 2026 Kartikey Tripathi
 </footer>
     </main>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `application/ld+json` script to the portfolio page with three schema.org types:
  - **Person** — name, job title, email, social profiles, employer, skills, location
  - **WebSite** — site name, URL, author reference
  - **ProfilePage** — links page to the Person entity

## Why
Structured data helps Google understand who the page is about and can trigger rich results (name, job title, links) in search — improving discoverability for the portfolio.

## Test plan
- [ ] Deploy and verify with [Google Rich Results Test](https://search.google.com/test/rich-results) at `https://www.kartikeytripathi.in`
- [ ] Confirm no TypeScript or build errors on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)