### PR TITLE
Add sitemap.xml and robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://www.kartikeytripathi.in/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,31 @@
+import { MetadataRoute } from "next";
+import { blogPosts } from "@/config/blog";
+
+const BASE_URL = "https://www.kartikeytripathi.in";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const blogRoutes = blogPosts
+    .filter((post) => !post.externalUrl)
+    .map((post) => ({
+      url: `${BASE_URL}/blog/${post.slug}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }));
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    ...blogRoutes,
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/sitemap.ts` — dynamically generates `/sitemap.xml` with all portfolio and blog routes
- Adds `src/app/robots.ts` — generates `/robots.txt` allowing all crawlers and pointing to the sitemap

## Sitemap includes
| URL | Priority | Change Frequency |
|-----|----------|-----------------|
| kartikeytripathi.in | 1.0 | Weekly |
| kartikeytripathi.in/blog | 0.8 | Weekly |
| Blog post slugs (non-external) | 0.6 | Monthly |

## Test plan
- [x] `GET /sitemap.xml` returns `200` with valid XML locally
- [x] `GET /robots.txt` returns `200` with correct directives locally
- [ ] After merge, submit sitemap in Google Search Console at `https://www.kartikeytripathi.in/sitemap.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)