### PR TITLE
feat: add animated terminal widget

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import {
   ContributionGraph,
   BlogSection,
   ErrorBoundary,
+  TerminalWidget,
 } from "@/components";
 
 const jsonLd = {
@@ -78,6 +79,10 @@ export default function Portfolio() {
     <main className="max-w-4xl mx-auto p-6 lg:p-8 bg-background text-foreground">
       <FadeInUp delay={0.1}>
   <HeroSection />
+</FadeInUp>
+
+<FadeInUp delay={0.15}>
+  <TerminalWidget />
 </FadeInUp>
 
 <div id="experience">

--- a/src/components/TerminalWidget.tsx
+++ b/src/components/TerminalWidget.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { motion } from "framer-motion";
+
+const PROMPT = "kartikey@aws:~$";
+const TYPE_SPEED = 55;
+const OUTPUT_LINE_DELAY = 120;
+const PAUSE_AFTER_OUTPUT = 2200;
+const PAUSE_BEFORE_NEXT = 600;
+
+const COMMANDS: { cmd: string; output: { text: string; color?: string }[] }[] =
+  [
+    {
+      cmd: "whoami",
+      output: [
+        { text: "kartikey-tripathi", color: "text-amber-400" },
+        { text: "Cloud & DevOps Engineer @ AWS", color: "text-blue-300" },
+        { text: "6.5+ yrs · EKS · Kubernetes · Terraform · AWS", color: "text-gray-400" },
+      ],
+    },
+    {
+      cmd: "kubectl get nodes",
+      output: [
+        { text: "NAME                           STATUS   ROLES    AGE   VERSION", color: "text-blue-300" },
+        { text: "ip-10-0-1-42.ec2.internal      Ready    <none>   18d   v1.31.2", color: "text-emerald-400" },
+        { text: "ip-10-0-2-87.ec2.internal      Ready    <none>   18d   v1.31.2", color: "text-emerald-400" },
+        { text: "ip-10-0-3-15.ec2.internal      Ready    <none>   18d   v1.31.2", color: "text-emerald-400" },
+      ],
+    },
+    {
+      cmd: "kubectl get pods -n production",
+      output: [
+        { text: "NAME                           READY   STATUS    RESTARTS   AGE", color: "text-blue-300" },
+        { text: "api-server-7d6f9b8c4-xk2pq    1/1     Running   0          2d", color: "text-emerald-400" },
+        { text: "worker-6c8b9d7f5-mn4rs         1/1     Running   0          2d", color: "text-emerald-400" },
+        { text: "redis-0                        1/1     Running   0          5d", color: "text-emerald-400" },
+      ],
+    },
+    {
+      cmd: "terraform plan",
+      output: [
+        { text: "Refreshing state...", color: "text-gray-400" },
+        { text: "─────────────────────────────────────────────", color: "text-gray-600" },
+        { text: "Plan: 3 to add, 1 to change, 0 to destroy.", color: "text-amber-400" },
+        { text: "Apply complete! Resources: 3 added, 1 changed.", color: "text-emerald-400" },
+      ],
+    },
+    {
+      cmd: "aws eks describe-cluster --name prod-cluster",
+      output: [
+        { text: "{", color: "text-gray-300" },
+        { text: '  "name":    "prod-cluster",', color: "text-blue-300" },
+        { text: '  "status":  "ACTIVE",', color: "text-emerald-400" },
+        { text: '  "version": "1.31"', color: "text-amber-400" },
+        { text: "}", color: "text-gray-300" },
+      ],
+    },
+  ];
+
+type HistoryEntry = {
+  cmd: string;
+  output: { text: string; color?: string }[];
+};
+
+export function TerminalWidget() {
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [typedCmd, setTypedCmd] = useState("");
+  const [visibleOutputLines, setVisibleOutputLines] = useState(0);
+  const [phase, setPhase] = useState<"typing" | "output" | "pause">("typing");
+  const [cmdIndex, setCmdIndex] = useState(0);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Scroll to bottom whenever content changes
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [history, typedCmd, visibleOutputLines]);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const currentCmd = COMMANDS[cmdIndex];
+
+    if (phase === "typing") {
+      if (typedCmd.length < currentCmd.cmd.length) {
+        timeout = setTimeout(() => {
+          setTypedCmd(currentCmd.cmd.slice(0, typedCmd.length + 1));
+        }, TYPE_SPEED);
+      } else {
+        timeout = setTimeout(() => {
+          setPhase("output");
+          setVisibleOutputLines(0);
+        }, 400);
+      }
+    } else if (phase === "output") {
+      if (visibleOutputLines < currentCmd.output.length) {
+        timeout = setTimeout(() => {
+          setVisibleOutputLines((n) => n + 1);
+        }, OUTPUT_LINE_DELAY);
+      } else {
+        timeout = setTimeout(() => {
+          setPhase("pause");
+        }, PAUSE_AFTER_OUTPUT);
+      }
+    } else if (phase === "pause") {
+      const nextIndex = (cmdIndex + 1) % COMMANDS.length;
+      // If we've looped, clear history to avoid growing forever
+      if (nextIndex === 0) {
+        timeout = setTimeout(() => {
+          setHistory([]);
+          setTypedCmd("");
+          setCmdIndex(0);
+          setPhase("typing");
+        }, PAUSE_BEFORE_NEXT);
+      } else {
+        timeout = setTimeout(() => {
+          setHistory((prev) => [
+            ...prev,
+            { cmd: currentCmd.cmd, output: currentCmd.output },
+          ]);
+          setCmdIndex(nextIndex);
+          setTypedCmd("");
+          setPhase("typing");
+        }, PAUSE_BEFORE_NEXT);
+      }
+    }
+
+    return () => clearTimeout(timeout);
+  }, [phase, typedCmd, visibleOutputLines, cmdIndex]);
+
+  const currentCmd = COMMANDS[cmdIndex];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 24 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      viewport={{ once: true }}
+      className="mb-16 w-full md:w-[90%] lg:w-[80%] xl:w-[78%] mx-auto"
+    >
+      {/* Title bar */}
+      <div className="flex items-center gap-2 px-4 py-3 bg-gray-800/80 rounded-t-xl border border-blue-500/30 border-b-gray-700/50">
+        <span className="w-3 h-3 rounded-full bg-red-500/80" />
+        <span className="w-3 h-3 rounded-full bg-amber-400/80" />
+        <span className="w-3 h-3 rounded-full bg-emerald-500/80" />
+        <span className="ml-3 text-xs text-gray-400 font-mono select-none">
+          kartikey@aws — zsh
+        </span>
+      </div>
+
+      {/* Terminal body */}
+      <div className="bg-gray-950/90 border border-blue-500/30 border-t-0 rounded-b-xl p-4 font-mono text-sm leading-relaxed min-h-[220px] max-h-[320px] overflow-y-auto scrollbar-none">
+        {/* Completed history */}
+        {history.map((entry, i) => (
+          <div key={i} className="mb-3">
+            <div className="flex gap-2">
+              <span className="text-emerald-400 shrink-0">{PROMPT}</span>
+              <span className="text-gray-100">{entry.cmd}</span>
+            </div>
+            {entry.output.map((line, j) => (
+              <div key={j} className={`pl-0 ${line.color ?? "text-gray-300"}`}>
+                {line.text}
+              </div>
+            ))}
+          </div>
+        ))}
+
+        {/* Active command line */}
+        <div className="flex gap-2">
+          <span className="text-emerald-400 shrink-0">{PROMPT}</span>
+          <span className="text-gray-100">{typedCmd}</span>
+          {phase === "typing" && (
+            <span className="animate-pulse text-amber-400">▋</span>
+          )}
+        </div>
+
+        {/* Active output lines */}
+        {phase !== "typing" &&
+          currentCmd.output.slice(0, visibleOutputLines).map((line, i) => (
+            <div key={i} className={line.color ?? "text-gray-300"}>
+              {line.text}
+            </div>
+          ))}
+
+        {/* Idle cursor after output */}
+        {phase === "pause" && (
+          <div className="flex gap-2 mt-3">
+            <span className="text-emerald-400 shrink-0">{PROMPT}</span>
+            <span className="animate-pulse text-amber-400">▋</span>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/TerminalWidget.tsx
+++ b/src/components/TerminalWidget.tsx
@@ -69,11 +69,12 @@ export function TerminalWidget() {
   const [visibleOutputLines, setVisibleOutputLines] = useState(0);
   const [phase, setPhase] = useState<"typing" | "output" | "pause">("typing");
   const [cmdIndex, setCmdIndex] = useState(0);
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
 
-  // Scroll to bottom whenever content changes
+  // Scroll terminal body (not the page) to bottom as new lines appear
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    const el = bodyRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
   }, [history, typedCmd, visibleOutputLines]);
 
   useEffect(() => {
@@ -149,7 +150,7 @@ export function TerminalWidget() {
       </div>
 
       {/* Terminal body */}
-      <div className="bg-gray-950/90 border border-blue-500/30 border-t-0 rounded-b-xl p-4 font-mono text-sm leading-relaxed min-h-[220px] max-h-[320px] overflow-y-auto scrollbar-none">
+      <div ref={bodyRef} className="bg-gray-950/90 border border-blue-500/30 border-t-0 rounded-b-xl p-4 font-mono text-sm leading-relaxed min-h-[220px] max-h-[320px] overflow-y-auto scrollbar-none">
         {/* Completed history */}
         {history.map((entry, i) => (
           <div key={i} className="mb-3">
@@ -190,7 +191,6 @@ export function TerminalWidget() {
           </div>
         )}
 
-        <div ref={bottomRef} />
       </div>
     </motion.div>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,4 +12,5 @@ export * from "./TechnicalSkills";
 export * from "./WorkExperience";
 export * from "./ui";
 export { default as ContributionGraph } from "./ContributionGraph";
+export * from "./TerminalWidget";
 


### PR DESCRIPTION
## Summary

- Adds `TerminalWidget` component — a fake animated terminal placed between the hero and work experience sections
- Auto-types through 5 real K8s/AWS commands with a realistic prompt (`kartikey@aws:~$`) and color-coded output
- Loops continuously; clears history on each full cycle to prevent DOM growth
- macOS-style title bar (red/yellow/green dots), amber blinking cursor, JetBrains Mono font
- Fully lint-clean (ESLint 9 + Next.js strict rules)

## Commands animated

| Command | What it shows |
|---|---|
| `whoami` | Name, role, years of experience |
| `kubectl get nodes` | 3 EKS nodes in Ready state |
| `kubectl get pods -n production` | 3 running pods |
| `terraform plan` | Plan summary with add/change counts |
| `aws eks describe-cluster` | JSON cluster status |

## Test plan

- [ ] Visit homepage and verify terminal appears below the hero
- [ ] Watch one full loop (all 5 commands) and confirm history clears cleanly
- [ ] Check on mobile — terminal should scroll horizontally within its container
- [ ] Verify no layout shift or hydration warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)