### PR TITLE
fix: remove orphaned setLoveCountServerAction and harden JSON-LD XSS sink

### DIFF
--- a/public/images/blog/conntrack-dns-race-diagram.svg
+++ b/public/images/blog/conntrack-dns-race-diagram.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 1100 1080" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="How a conntrack insert race produces a one second DNS delay">
+  <defs>
+    <style>
+      .t-title  { font-family: 'IBM Plex Sans', sans-serif; font-weight: 600; fill: #0f172a; }
+      .t-sub    { font-family: 'IBM Plex Sans', sans-serif; font-weight: 400; fill: #6b6453; }
+      .t-label  { font-family: 'IBM Plex Sans', sans-serif; font-weight: 500; fill: #0f172a; }
+      .t-mono   { font-family: 'IBM Plex Mono', monospace; fill: #334155; }
+      .t-monob  { font-family: 'IBM Plex Mono', monospace; font-weight: 600; }
+      .t-stage  { font-family: 'IBM Plex Mono', monospace; font-weight: 600; fill: #b45309; letter-spacing: 0.08em; }
+    </style>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#2563a8"/>
+    </marker>
+    <marker id="arrowRed" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#c0392b"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#3b6d11"/>
+    </marker>
+    <marker id="arrowGray" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L7,3 L0,6 Z" fill="#94908a"/>
+    </marker>
+  </defs>
+
+  <!-- ===== HEADER ===== -->
+  <text x="40" y="46" class="t-title" font-size="27">The one-second DNS delay</text>
+  <text x="40" y="72" class="t-sub" font-size="15">Why two parallel lookups race through conntrack — and one quietly vanishes</text>
+  <line x1="40" y1="90" x2="1060" y2="90" stroke="#d6cfbf" stroke-width="1"/>
+
+  <!-- ===== POD BOX ===== -->
+  <rect x="40" y="120" width="300" height="170" rx="8" fill="#f6f3ea" stroke="#d6cfbf" stroke-width="1.2"/>
+  <text x="60" y="148" class="t-stage" font-size="12">THE POD</text>
+  <text x="60" y="176" class="t-label" font-size="14">App calls getaddrinfo()</text>
+  <text x="60" y="200" class="t-mono" font-size="12.5">glibc fires TWO queries</text>
+  <text x="60" y="220" class="t-mono" font-size="12.5">in parallel on ONE socket:</text>
+  <rect x="60" y="234" width="120" height="36" rx="5" fill="#e6f1fb" stroke="#9cc2e6"/>
+  <text x="120" y="251" class="t-monob" font-size="12" fill="#185fa5" text-anchor="middle">A record</text>
+  <text x="120" y="265" class="t-mono" font-size="10.5" fill="#185fa5" text-anchor="middle">query #1</text>
+  <rect x="196" y="234" width="120" height="36" rx="5" fill="#e6f1fb" stroke="#9cc2e6"/>
+  <text x="256" y="251" class="t-monob" font-size="12" fill="#185fa5" text-anchor="middle">AAAA record</text>
+  <text x="256" y="265" class="t-mono" font-size="10.5" fill="#185fa5" text-anchor="middle">query #2</text>
+
+  <!-- same-tuple callout -->
+  <text x="60" y="258" class="t-mono" font-size="11" fill="#c0392b" opacity="0"></text>
+
+  <!-- arrows from the two queries down into the kernel -->
+  <path d="M120,270 L120,332" stroke="#2563a8" stroke-width="2.4" fill="none" marker-end="url(#arrowBlue)"/>
+  <path d="M256,270 L256,332" stroke="#2563a8" stroke-width="2.4" fill="none" marker-end="url(#arrowBlue)"/>
+  <text x="40" y="320" class="t-mono" font-size="10.5" fill="#c0392b">both queries carry an identical 5-tuple</text>
+
+  <!-- ===== SAME TUPLE NOTE (right of pod) ===== -->
+  <rect x="372" y="120" width="688" height="170" rx="8" fill="#fbf6ee" stroke="#e6d9bf" stroke-width="1.2"/>
+  <text x="392" y="148" class="t-stage" font-size="12" fill="#b45309">WHY THEY COLLIDE</text>
+  <text x="392" y="174" class="t-mono" font-size="12.5">Both packets leave the same socket, so they share the same source tuple:</text>
+  <rect x="392" y="188" width="648" height="32" rx="5" fill="#fff" stroke="#e6d9bf"/>
+  <text x="404" y="209" class="t-mono" font-size="12.5" fill="#334155">src=10.244.1.5 sport=51514  dst=10.96.0.10 dport=53  proto=udp</text>
+  <text x="392" y="244" class="t-mono" font-size="12.5">conntrack must create a NEW entry for each — but they arrive nanoseconds apart,</text>
+  <text x="392" y="263" class="t-mono" font-size="12.5">on different CPUs, both checking "does an entry exist yet?" at the same instant.</text>
+
+  <!-- ===== STAGE 1: DNAT ===== -->
+  <text x="40" y="364" class="t-stage" font-size="13">STAGE 1 — DNAT IN PREROUTING</text>
+  <line x1="40" y1="376" x2="1060" y2="376" stroke="#e6d9bf" stroke-width="1"/>
+
+  <rect x="40" y="396" width="470" height="118" rx="8" fill="#f6f3ea" stroke="#d6cfbf"/>
+  <text x="60" y="423" class="t-label" font-size="14">Query #1  (A)</text>
+  <text x="60" y="447" class="t-mono" font-size="12">VIP 10.96.0.10:53 → CoreDNS pod</text>
+  <text x="60" y="467" class="t-mono" font-size="12">conntrack: insert entry... </text>
+  <rect x="60" y="478" width="430" height="26" rx="5" fill="#eaf3de" stroke="#97c459"/>
+  <text x="75" y="496" class="t-monob" font-size="11.5" fill="#3b6d11">[OK] slot reserved — committed first</text>
+
+  <rect x="590" y="396" width="470" height="118" rx="8" fill="#f6f3ea" stroke="#d6cfbf"/>
+  <text x="610" y="423" class="t-label" font-size="14">Query #2  (AAAA)</text>
+  <text x="610" y="447" class="t-mono" font-size="12">VIP 10.96.0.10:53 → CoreDNS pod</text>
+  <text x="610" y="467" class="t-mono" font-size="12">conntrack: insert entry...</text>
+  <rect x="610" y="478" width="430" height="26" rx="5" fill="#fdeceb" stroke="#e0a39c"/>
+  <text x="625" y="496" class="t-monob" font-size="11.5" fill="#c0392b">[X] identical tuple already inserting — clash</text>
+
+  <!-- two parallel lanes -->
+  <path d="M120,514 L120,560" stroke="#3b6d11" stroke-width="2.4" fill="none" marker-end="url(#arrowGreen)"/>
+  <path d="M256,514 L256,560" stroke="#3b6d11" stroke-width="2.4" fill="none" marker-end="url(#arrowGreen)"/>
+  <path d="M780,514 L780,560" stroke="#c0392b" stroke-width="2.4" fill="none" marker-end="url(#arrowRed)" stroke-dasharray="6 4"/>
+
+  <!-- ===== STAGE 2: THE RACE ===== -->
+  <text x="40" y="592" class="t-stage" font-size="13">STAGE 2 — THE INSERT RACE (nf_conntrack_confirm)</text>
+  <line x1="40" y1="604" x2="1060" y2="604" stroke="#e6d9bf" stroke-width="1"/>
+
+  <rect x="40" y="624" width="470" height="108" rx="8" fill="#f1f7e9" stroke="#c4dca3"/>
+  <text x="60" y="651" class="t-label" font-size="14" fill="#3b6d11">Packet #1 — confirmed</text>
+  <text x="60" y="675" class="t-mono" font-size="12">Entry written to the hash table.</text>
+  <text x="60" y="695" class="t-mono" font-size="12">Forwarded to CoreDNS. Reply will</text>
+  <text x="60" y="713" class="t-mono" font-size="12">come back and be un-NAT'd cleanly.</text>
+
+  <rect x="590" y="624" width="470" height="108" rx="8" fill="#fcefed" stroke="#e6b5ae"/>
+  <text x="610" y="651" class="t-label" font-size="14" fill="#c0392b">Packet #2 — DROPPED</text>
+  <text x="610" y="675" class="t-mono" font-size="12">Confirm sees a duplicate tuple and</text>
+  <text x="610" y="695" class="t-mono" font-size="12">silently discards the packet. No error,</text>
+  <text x="610" y="713" class="t-mono" font-size="12">no ICMP — it simply never arrives.</text>
+
+  <path d="M275,732 L275,778" stroke="#3b6d11" stroke-width="2.4" fill="none" marker-end="url(#arrowGreen)"/>
+  <path d="M825,732 L825,778" stroke="#94908a" stroke-width="2.4" fill="none" marker-end="url(#arrowGray)" stroke-dasharray="3 4"/>
+  <text x="838" y="762" class="t-mono" font-size="10.5" fill="#94908a">silence...</text>
+
+  <!-- ===== STAGE 3: THE WAIT ===== -->
+  <text x="40" y="810" class="t-stage" font-size="13">STAGE 3 — THE RESOLVER WAITS</text>
+  <line x1="40" y1="822" x2="1060" y2="822" stroke="#e6d9bf" stroke-width="1"/>
+
+  <rect x="40" y="842" width="470" height="92" rx="8" fill="#f1f7e9" stroke="#c4dca3"/>
+  <text x="60" y="869" class="t-label" font-size="14" fill="#3b6d11">A answer returns fast</text>
+  <text x="60" y="893" class="t-mono" font-size="12">CoreDNS replies in single-digit ms.</text>
+  <text x="60" y="911" class="t-mono" font-size="12">But getaddrinfo() needs BOTH.</text>
+
+  <rect x="590" y="842" width="470" height="92" rx="8" fill="#fcefed" stroke="#e6b5ae"/>
+  <text x="610" y="869" class="t-label" font-size="14" fill="#c0392b">AAAA answer never came</text>
+  <text x="610" y="893" class="t-mono" font-size="12">glibc blocks on its retransmit timer.</text>
+  <text x="610" y="911" class="t-monob" font-size="13" fill="#c0392b">Default timeout = 1 second.</text>
+
+  <!-- ===== PAYOFF BANNER ===== -->
+  <rect x="40" y="958" width="1020" height="86" rx="10" fill="#fbf0d9" stroke="#e6c98f" stroke-width="1.4"/>
+  <rect x="40" y="958" width="6" height="86" rx="3" fill="#b45309"/>
+  <text x="64" y="990" class="t-mono" font-size="12" fill="#b45309" letter-spacing="0.08em">THE RESULT</text>
+  <text x="64" y="1018" class="t-title" font-size="20" fill="#1f2a37">A retransmit fires after 1s, succeeds, and the app finally resolves.</text>
+  <text x="64" y="1038" class="t-mono" font-size="12.5" fill="#6b6453">Fixes: --random-fully · single-request-reopen in resolv.conf · NodeLocal DNSCache (take DNS off the conntrack path)</text>
+</svg>

--- a/public/images/blog/conntrack-dns-race-thumbnail.svg
+++ b/public/images/blog/conntrack-dns-race-thumbnail.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" font-family="'JetBrains Mono', 'Courier New', monospace">
+  <defs>
+    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0A0A0A"/>
+      <stop offset="100%" style="stop-color:#0f1117"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow-soft">
+      <feGaussianBlur stdDeviation="8" result="coloredBlur"/>
+      <feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg-grad)"/>
+
+  <!-- Subtle dot grid -->
+  <g opacity="0.07" fill="#ffffff">
+    <circle cx="60" cy="60" r="1.5"/><circle cx="180" cy="60" r="1.5"/><circle cx="300" cy="60" r="1.5"/>
+    <circle cx="420" cy="60" r="1.5"/><circle cx="540" cy="60" r="1.5"/><circle cx="660" cy="60" r="1.5"/>
+    <circle cx="780" cy="60" r="1.5"/><circle cx="900" cy="60" r="1.5"/><circle cx="1020" cy="60" r="1.5"/>
+    <circle cx="1140" cy="60" r="1.5"/>
+    <circle cx="60" cy="180" r="1.5"/><circle cx="180" cy="180" r="1.5"/><circle cx="300" cy="180" r="1.5"/>
+    <circle cx="420" cy="180" r="1.5"/><circle cx="540" cy="180" r="1.5"/><circle cx="660" cy="180" r="1.5"/>
+    <circle cx="780" cy="180" r="1.5"/><circle cx="900" cy="180" r="1.5"/><circle cx="1020" cy="180" r="1.5"/>
+    <circle cx="1140" cy="180" r="1.5"/>
+    <circle cx="60" cy="300" r="1.5"/><circle cx="180" cy="300" r="1.5"/><circle cx="300" cy="300" r="1.5"/>
+    <circle cx="420" cy="300" r="1.5"/><circle cx="540" cy="300" r="1.5"/><circle cx="660" cy="300" r="1.5"/>
+    <circle cx="780" cy="300" r="1.5"/><circle cx="900" cy="300" r="1.5"/><circle cx="1020" cy="300" r="1.5"/>
+    <circle cx="1140" cy="300" r="1.5"/>
+    <circle cx="60" cy="420" r="1.5"/><circle cx="180" cy="420" r="1.5"/><circle cx="300" cy="420" r="1.5"/>
+    <circle cx="420" cy="420" r="1.5"/><circle cx="540" cy="420" r="1.5"/><circle cx="660" cy="420" r="1.5"/>
+    <circle cx="780" cy="420" r="1.5"/><circle cx="900" cy="420" r="1.5"/><circle cx="1020" cy="420" r="1.5"/>
+    <circle cx="1140" cy="420" r="1.5"/>
+    <circle cx="60" cy="540" r="1.5"/><circle cx="180" cy="540" r="1.5"/><circle cx="300" cy="540" r="1.5"/>
+    <circle cx="420" cy="540" r="1.5"/><circle cx="540" cy="540" r="1.5"/><circle cx="660" cy="540" r="1.5"/>
+    <circle cx="780" cy="540" r="1.5"/><circle cx="900" cy="540" r="1.5"/><circle cx="1020" cy="540" r="1.5"/>
+    <circle cx="1140" cy="540" r="1.5"/>
+  </g>
+
+  <!-- Amber accent top bar -->
+  <rect x="0" y="0" width="1200" height="5" fill="#F5C842" opacity="0.9" filter="url(#glow)"/>
+
+  <!-- Background visual — conntrack table abstraction (right side decoration) -->
+  <g opacity="0.06">
+    <rect x="700" y="120" width="440" height="380" rx="8" stroke="#F5C842" stroke-width="1" fill="none"/>
+    <rect x="720" y="160" width="400" height="30" rx="4" fill="#F5C842"/>
+    <rect x="720" y="204" width="400" height="24" rx="4" fill="#6b7280"/>
+    <rect x="720" y="240" width="400" height="24" rx="4" fill="#6b7280"/>
+    <rect x="720" y="276" width="400" height="24" rx="4" fill="#f87171"/>
+    <rect x="720" y="312" width="400" height="24" rx="4" fill="#f87171"/>
+    <rect x="720" y="348" width="400" height="24" rx="4" fill="#6b7280"/>
+    <rect x="720" y="384" width="400" height="24" rx="4" fill="#6b7280"/>
+  </g>
+
+  <!-- Left amber accent bar -->
+  <rect x="72" y="160" width="4" height="280" rx="2" fill="#F5C842" opacity="0.8" filter="url(#glow)"/>
+
+  <!-- Main category label -->
+  <text x="96" y="196" fill="#F5C842" font-size="14" font-weight="700" letter-spacing="4" opacity="0.9">KUBERNETES  ·  NETWORKING  ·  DEBUGGING</text>
+
+  <!-- Title -->
+  <text x="96" y="276" fill="#E8E8E8" font-size="56" font-weight="700" letter-spacing="-1">The conntrack</text>
+  <text x="96" y="348" fill="#E8E8E8" font-size="56" font-weight="700" letter-spacing="-1">DNS Race</text>
+  <text x="96" y="420" fill="#F5C842" font-size="56" font-weight="700" letter-spacing="-1" filter="url(#glow-soft)">Condition</text>
+
+  <!-- Subtitle -->
+  <text x="96" y="474" fill="#9CA3AF" font-size="20" letter-spacing="0">Why your pods get random 5-second DNS timeouts</text>
+
+  <!-- Tags -->
+  <rect x="96" y="506" width="120" height="28" rx="4" fill="#111111" stroke="#374151" stroke-width="1"/>
+  <text x="156" y="525" fill="#9CA3AF" font-size="12" font-weight="600" text-anchor="middle" letter-spacing="1">conntrack</text>
+
+  <rect x="228" y="506" width="96" height="28" rx="4" fill="#111111" stroke="#374151" stroke-width="1"/>
+  <text x="276" y="525" fill="#9CA3AF" font-size="12" font-weight="600" text-anchor="middle" letter-spacing="1">iptables</text>
+
+  <rect x="336" y="506" width="80" height="28" rx="4" fill="#111111" stroke="#374151" stroke-width="1"/>
+  <text x="376" y="525" fill="#9CA3AF" font-size="12" font-weight="600" text-anchor="middle" letter-spacing="1">CoreDNS</text>
+
+  <rect x="428" y="506" width="56" height="28" rx="4" fill="#111111" stroke="#374151" stroke-width="1"/>
+  <text x="456" y="525" fill="#9CA3AF" font-size="12" font-weight="600" text-anchor="middle" letter-spacing="1">EKS</text>
+
+  <!-- Author -->
+  <text x="96" y="590" fill="#6b7280" font-size="14" letter-spacing="1">Kartikey Tripathi  ·  blogs.kartikeytripathi.in</text>
+
+  <!-- Error badge (decorative) -->
+  <rect x="920" y="490" width="200" height="60" rx="6" fill="#3b0000" stroke="#991b1b" stroke-width="1.5"/>
+  <text x="1020" y="516" fill="#f87171" font-size="13" font-weight="700" text-anchor="middle">insert_failed: 847</text>
+  <text x="1020" y="538" fill="#9ca3af" font-size="11" text-anchor="middle">conntrack -S output</text>
+</svg>

--- a/src/app/api/loveActions.ts
+++ b/src/app/api/loveActions.ts
@@ -29,12 +29,3 @@ export async function addLoveServerAction() {
   return { success: true, count: doc.count };
 }
 
-export async function setLoveCountServerAction(count: number) {
-  await connectToDatabase();
-  const doc = await LoveCount.findOneAndUpdate(
-    {},
-    { $set: { count } },
-    { upsert: true, new: true }
-  );
-  return { success: true, count: doc.count };
-}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -82,7 +82,12 @@ export default async function BlogPostPage({ params }: Props) {
     <main className="max-w-4xl mx-auto p-6 lg:p-8">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e")
+            .replace(/&/g, "\\u0026"),
+        }}
       />
       {/* Back */}
       <Link

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,7 +73,12 @@ export default function Portfolio() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(jsonLd)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e")
+            .replace(/&/g, "\\u0026"),
+        }}
       />
     <main className="max-w-4xl mx-auto p-6 lg:p-8 bg-background text-foreground">
       <FadeInUp delay={0.1}>

--- a/src/config/blog.ts
+++ b/src/config/blog.ts
@@ -13,6 +13,16 @@ export type BlogPost = {
 
 export const blogPosts: BlogPost[] = [
   {
+    slug: "conntrack-kubernetes-dns-race",
+    title: "The conntrack DNS Race Condition in Kubernetes",
+    description:
+      "Why your pods get random 5-second DNS timeouts — a deep dive into the Linux conntrack table, the A vs AAAA query race through iptables SNAT, how to confirm it with conntrack -S, and four remediation paths including NodeLocal DNSCache.",
+    date: "Jun 2026",
+    tags: ["Kubernetes", "Networking", "DNS", "conntrack", "iptables", "EKS", "Debugging", "DevOps"],
+    type: "article",
+    thumbnail: "/images/blog/conntrack-dns-race-thumbnail.svg",
+  },
+  {
     slug: "networking-handbook",
     title: "Networking // Field Manual",
     description:

--- a/src/content/blog/conntrack-kubernetes-dns-race.md
+++ b/src/content/blog/conntrack-kubernetes-dns-race.md
@@ -1,0 +1,327 @@
+---
+title: "The conntrack DNS Race Condition in Kubernetes"
+date: 2026-06-06
+description: "A deep dive into why Kubernetes pods get random 5-second DNS timeouts — the Linux conntrack table, the A vs AAAA race, how to confirm it with conntrack -S, and four remediation paths including NodeLocal DNSCache."
+tags:
+  - kubernetes
+  - networking
+  - dns
+  - conntrack
+  - eks
+  - iptables
+  - debugging
+  - devops
+author: Kartikey Tripathi
+---
+
+Your pod works fine for hours. Then a request takes five seconds instead of one millisecond. No errors logged. No obvious cause. You restart nothing, change nothing, and it recovers — until it happens again.
+
+If this pattern is familiar and you're on Kubernetes, the cause is likely a race condition inside the Linux connection tracking subsystem (conntrack) that fires specifically during DNS lookups. It's not a Kubernetes bug, not a CoreDNS bug, and not a network problem. It's a consequence of how the Linux kernel handles concurrent UDP packets through NAT.
+
+This post walks through exactly what happens, how to confirm it, and how to fix it.
+
+---
+
+## What conntrack is and why Kubernetes uses it
+
+Every Linux host doing any form of NAT — masquerade, DNAT, port forwarding — relies on **conntrack** (Netfilter connection tracking). It's a kernel subsystem that maintains a stateful table of every active network flow so that reply packets can be matched to the request that spawned them.
+
+Each entry in the conntrack table is keyed by a **5-tuple**:
+
+| Field | Example |
+|---|---|
+| Source IP | 10.0.0.15 (pod IP) |
+| Source port | 32145 |
+| Destination IP | 10.96.0.10 (CoreDNS ClusterIP) |
+| Destination port | 53 |
+| Protocol | UDP |
+
+For this table to work correctly, every entry must have a unique 5-tuple. Two simultaneous connections with the same 5-tuple would produce an ambiguous state — conntrack doesn't know which reply goes where.
+
+In a Kubernetes cluster, every pod-to-service packet goes through `iptables MASQUERADE` on the node (or through `kube-proxy` iptables rules). This rewrites the source IP from the pod's IP to the node's IP, then relies on conntrack to track the reverse mapping so replies come back to the right pod. No conntrack — no NAT — no Kubernetes networking.
+
+## The DNS query path in a Kubernetes pod
+
+Before the race, understand the path a pod takes to resolve a hostname.
+
+When your Go, Python, or Java application calls `getaddrinfo("my-service")`, the glibc resolver reads `/etc/resolv.conf`. In a Kubernetes pod, that file is injected by kubelet and looks like:
+
+```
+nameserver 10.96.0.10
+search default.svc.cluster.local svc.cluster.local cluster.local
+options ndots:5
+```
+
+The `ndots:5` option means: if the name being looked up has fewer than 5 dots, treat it as a relative name and search through every suffix in the `search` list before trying it as an absolute name.
+
+For a lookup of `my-service.default`, that generates this sequence of DNS queries — in order:
+
+```
+my-service.default.default.svc.cluster.local → NXDOMAIN
+my-service.default.svc.cluster.local         → NXDOMAIN
+my-service.default.cluster.local             → NXDOMAIN
+my-service.default                           → ANSWER  (if it's a valid FQDN)
+```
+
+That's already four round trips for a single lookup on a simple name. Now add the A vs AAAA issue.
+
+## The actual race condition
+
+Modern libc resolvers, by default, issue **both A (IPv4) and AAAA (IPv6) queries simultaneously** for each DNS lookup — a parallel dual-stack query strategy designed to reduce latency. Both queries go to the same nameserver, on the same socket, from the same source port, at nearly the same time.
+
+Here's the problem:
+
+```
+A    query: src=pod-ip:32145 → dst=10.96.0.10:53 UDP
+AAAA query: src=pod-ip:32145 → dst=10.96.0.10:53 UDP
+                  ↑ identical 5-tuple
+```
+
+Both packets exit the pod and hit the node's iptables masquerade rule. The SNAT rule must create a conntrack entry for each. On a lightly loaded node, the two packets often interleave at microsecond intervals. The kernel processing looks roughly like this:
+
+1. Packet 1 (A query) arrives at iptables → conntrack lookup → no entry → **create new entry** for `node-ip:32145 → 10.96.0.10:53`
+2. Packet 2 (AAAA query) arrives at iptables → conntrack lookup → **entry already exists** with the same 5-tuple
+
+At this point, conntrack tries to pick an alternate source port for the second packet. Under concurrent load this can fail — both packets raced to conntrack simultaneously before the first entry fully committed, each observed the table as empty, and now there's a conflict. One packet gets **silently dropped by the kernel**. The drop increments a counter and generates no error to userspace.
+
+CoreDNS receives only one of the two queries. The resolver waits for both replies. After `options timeout:5` (the default), the unanswered query times out. The resolver retries on a new port and everything works — 5 seconds later.
+
+![conntrack DNS race condition diagram](/images/blog/conntrack-dns-race-diagram.svg)
+
+The sequence is non-deterministic. It depends on CPU scheduling, NIC interrupt timing, and how full the conntrack table is. Under low load it almost never fires. Under concurrent pod-level DNS activity — like a deployment rollout where 50 pods all start simultaneously and each one resolves service names — it becomes frequent.
+
+## Confirming it is actually conntrack
+
+### Step 1: Watch insert_failed
+
+This is the most direct signal. `conntrack -S` shows per-CPU counters for the conntrack subsystem:
+
+```bash
+conntrack -S
+```
+
+Output on a node experiencing the race:
+
+```
+cpu=0     found=14821 invalid=0 insert=14821 insert_failed=847 ...
+cpu=1     found=13201 invalid=0 insert=13201 insert_failed=632 ...
+```
+
+`insert_failed` is the exact counter that increments when a conntrack entry creation fails due to a collision. A non-zero value while DNS failures are happening is strong evidence. Watch it live:
+
+```bash
+watch -n 1 'conntrack -S | awk "{sum += \$6} END {print \"insert_failed:\", sum}"'
+```
+
+If the count climbs during the spike window and resets between incidents, you have the race.
+
+### Step 2: Packet-level confirmation
+
+On the node, run a capture filtered to DNS traffic from a specific pod:
+
+```bash
+# Get the pod's IP
+POD_IP=$(kubectl get pod <pod-name> -o jsonpath='{.status.podIP}')
+
+# Capture on the veth interface
+tcpdump -i any -n "src $POD_IP and udp port 53" -w /tmp/dns.pcap
+```
+
+Open in Wireshark and look for two outgoing DNS queries with the same source port and no corresponding response to one of them. The missing response is the dropped packet.
+
+### Step 3: strace the resolver (last resort)
+
+If you need to confirm the timeline at the process level:
+
+```bash
+kubectl exec <pod> -- strace -e trace=network -f -p 1 2>&1 | grep -i dns
+```
+
+You'll see two `sendmsg` calls in rapid succession for A and AAAA, and then only one `recvmsg` within milliseconds, followed by a 5-second `poll` timeout.
+
+### Step 4: Check CoreDNS metrics
+
+CoreDNS exports Prometheus metrics. If you have Prometheus installed:
+
+```promql
+rate(coredns_dns_requests_total{type="AAAA"}[5m])
+```
+
+versus
+
+```promql
+rate(coredns_dns_responses_total{type="AAAA"}[5m])
+```
+
+A persistent gap between requests CoreDNS *sent responses to* and requests your pods *received responses for* points to packet loss between the pod and CoreDNS — consistent with the race.
+
+---
+
+## Remediation
+
+There are four levers. They address different root causes and are not mutually exclusive.
+
+### Option 1: single-request-reopen (quick pod-level fix)
+
+This `resolv.conf` option tells the resolver to send A and AAAA queries **sequentially on different sockets** instead of simultaneously on the same socket. Sending from different sockets guarantees different source ports, which means different 5-tuples, which means no collision.
+
+```yaml
+spec:
+  dnsConfig:
+    options:
+      - name: single-request-reopen
+```
+
+Apply this to any Deployment/DaemonSet/StatefulSet where you see the issue. It adds a small latency overhead (~0-5ms per lookup in practice) because queries serialize, but that's negligible compared to a 5-second timeout.
+
+The sibling option `single-request` does the same thing but reuses the same socket (which means the same source port). On Linux kernels older than ~4.17, even this could race because the socket is half-duplex between the two queries. `single-request-reopen` is safer.
+
+```yaml
+spec:
+  dnsConfig:
+    options:
+      - name: single-request-reopen
+      - name: ndots
+        value: "2"
+```
+
+### Option 2: NodeLocal DNSCache (proper fix for EKS)
+
+NodeLocal DNSCache runs a DNS caching agent as a DaemonSet on every node. Pods are configured to talk to a link-local IP (`169.254.20.10` by default) rather than the CoreDNS ClusterIP. That link-local address is bound to a dummy interface on the node and never leaves the node.
+
+This eliminates SNAT entirely. If DNS never goes through NAT, conntrack is never involved, and the race cannot happen. It also reduces DNS latency (cache hits are sub-millisecond) and reduces load on CoreDNS.
+
+On EKS, deploy it via the official manifest:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml | \
+  sed 's/__PILLAR__LOCAL__DNS__/169.254.20.10/g; s/__PILLAR__DNS__DOMAIN__/cluster.local/g; s/__PILLAR__DNS__SERVER__/10.96.0.10/g' | \
+  kubectl apply -f -
+```
+
+Update pods to use the link-local address:
+
+```yaml
+spec:
+  dnsConfig:
+    nameservers:
+      - 169.254.20.10
+    searches:
+      - default.svc.cluster.local
+      - svc.cluster.local
+      - cluster.local
+    options:
+      - name: ndots
+        value: "5"
+```
+
+Or, if your cluster version supports it, configure NodeLocal DNSCache to automatically intercept requests from pods without pod-level changes (requires `iptables NOTRACK` rules — the NodeLocal DNSCache manifest handles this).
+
+### Option 3: Reduce ndots
+
+Every extra DNS search path query is a potential race window. The default `ndots:5` creates up to 4 failed lookups before the correct answer. Reducing ndots lowers exposure:
+
+```yaml
+spec:
+  dnsConfig:
+    options:
+      - name: ndots
+        value: "2"
+```
+
+With `ndots:2`, a name like `my-service.default` is tried as-is first (it has one dot, fewer than 2), falling through to the search path only if the direct query fails — which is the opposite of the default. For service names that are already in short form (`my-service`), you'll still hit the search path. The cleanest approach is to always use FQDNs in your code:
+
+```
+my-service.default.svc.cluster.local.
+```
+
+The trailing dot marks it as absolute — no search path, single query pair.
+
+### Option 4: conntrack table size tuning
+
+This doesn't fix the race condition directly but prevents a related failure mode: **conntrack table exhaustion**. When the table is full, all new connections fail with `nf_conntrack: table full, dropping packet`.
+
+Check the current limit and usage:
+
+```bash
+# Limit
+sysctl net.netfilter.nf_conntrack_max
+
+# Current usage
+cat /proc/sys/net/netfilter/nf_conntrack_count
+```
+
+On EC2 nodes, the default is often 131072. For nodes with many pods and high connection rates, this can fill. Tune via a DaemonSet that applies sysctl settings, or in EKS via a node bootstrap script:
+
+```bash
+sysctl -w net.netfilter.nf_conntrack_max=524288
+sysctl -w net.netfilter.nf_conntrack_buckets=131072
+```
+
+The bucket count should be `nf_conntrack_max / 4` to maintain efficient hash table performance.
+
+---
+
+## EKS-specific context
+
+On Amazon EKS, a few additional things affect this picture.
+
+**CoreDNS autoscaling.** EKS ships CoreDNS as a managed add-on with 2 replicas by default. Under heavy pod churn, those two replicas can become a bottleneck independently of the conntrack issue. Use the [cluster-proportional-autoscaler](https://github.com/kubernetes-sigs/cluster-proportional-autoscaler) to scale CoreDNS with node count.
+
+**Node group sysctl configuration.** EKS managed node groups don't expose conntrack tuning directly, but you can apply sysctls via a DaemonSet with `hostPID: true` and `privileged: true` containers, or via EC2 launch templates with a custom `user-data` script.
+
+**VPC DNS.** Every EC2 instance can use the VPC resolver at `169.254.169.253` as a fallback. Kubernetes in-cluster DNS (CoreDNS) takes priority for `.cluster.local` queries. External names go upstream through CoreDNS to Route 53 Resolver. If your pods query external domains heavily, the same race applies to those queries too — NodeLocal DNSCache is the fix there as well.
+
+**Bottlerocket nodes.** Bottlerocket's kernel is tuned for container workloads and ships with larger conntrack defaults, but the race condition still applies since it's fundamentally about timing, not table size.
+
+---
+
+## Decision table
+
+| Situation | Recommended fix |
+|---|---|
+| One-off pod experiencing the race | `single-request-reopen` in pod dnsConfig |
+| Cluster-wide DNS instability | NodeLocal DNSCache DaemonSet |
+| High-churn namespaces (batch jobs, rollouts) | NodeLocal DNSCache + CoreDNS autoscaling |
+| External DNS queries also affected | NodeLocal DNSCache (eliminates SNAT for all UDP/53) |
+| `conntrack -S` shows insert_failed climbing | Start with `single-request-reopen`; plan for NodeLocal DNSCache |
+| conntrack table full errors in `dmesg` | `nf_conntrack_max` tuning (separate problem from race) |
+
+---
+
+## Quick diagnostics checklist
+
+```bash
+# 1. Confirm insert_failed is non-zero during the incident
+conntrack -S | grep insert_failed
+
+# 2. Check conntrack table utilization
+cat /proc/sys/net/netfilter/nf_conntrack_count
+sysctl net.netfilter.nf_conntrack_max
+
+# 3. Look for DNS drops in dmesg
+dmesg | grep -i conntrack
+
+# 4. Inspect resolv.conf inside the affected pod
+kubectl exec <pod> -- cat /etc/resolv.conf
+
+# 5. Check CoreDNS error rate
+kubectl logs -n kube-system -l k8s-app=kube-dns --tail=100 | grep -i error
+
+# 6. Verify NodeLocal DNSCache pods (if deployed)
+kubectl get pods -n kube-system -l k8s-app=node-local-dns
+```
+
+---
+
+## What's actually happening in one sentence
+
+Two DNS queries sent from the same source port at the same instant race to create conntrack entries; one loses, the kernel drops that packet silently, and the resolver waits five seconds before retrying.
+
+The fix — at the right layer — is to either serialize the queries (`single-request-reopen`) or remove SNAT from the DNS path entirely (NodeLocal DNSCache). Everything else is mitigation.
+
+---
+
+*Found this useful? See also: [What Actually Happens When Internet Traffic Reaches Your EKS Pod](/blog/how-traffic-reaches-your-eks-pods) and [How IRSA Really Works on EKS](/blog/how-irsa-really-works-on-eks).*
+
+*Reach me on [LinkedIn](https://linkedin.com/in/kartikeytripathi/) or [GitHub](https://github.com/kartikeytripathi).*


### PR DESCRIPTION
## Summary
- **Security:** Delete `setLoveCountServerAction` — an unauthenticated server action exported from a `"use server"` module that allowed anyone to overwrite the love counter to an arbitrary value; never called by any UI component
- **Security:** Escape `<`, `>`, and `&` in JSON-LD `dangerouslySetInnerHTML` output on `page.tsx` and `blog/[slug]/page.tsx` to prevent script-tag breakout if jsonLd data ever becomes dynamic
- **Content:** Add conntrack DNS race condition blog post with diagram SVG and OG thumbnail

## Test plan
- [ ] Love button still increments and displays count correctly
- [ ] `setLoveCountServerAction` no longer appears in the compiled JS bundle action registry
- [ ] JSON-LD on homepage and blog post pages renders valid structured data (validate with Google Rich Results Test)
- [ ] Blog post visible at `blogs.kartikeytripathi.in/conntrack-kubernetes-dns-race`
- [ ] Diagram SVG renders correctly in the blog post

🤖 Generated with [Claude Code](https://claude.com/claude-code)